### PR TITLE
[refactor] 공통 예외 처리 구조 개선: Interface 기반 에러 코드 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     api 'com.fasterxml.jackson.core:jackson-databind'
     api 'org.springframework.boot:spring-boot-starter-validation' // @NotNull 등
+    api 'org.springframework.boot:spring-boot-starter-web'
 
     // 2. JWT (jjwt)
     api 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/kr/gilmok/common/dto/ErrorResponse.java
+++ b/src/main/java/kr/gilmok/common/dto/ErrorResponse.java
@@ -1,16 +1,27 @@
 package kr.gilmok.common.dto;
 
+import kr.gilmok.common.exception.ErrorCode;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class ErrorResponse {
-    private String status;   // "error" 고정
-    private String code;     // "U001", "S001" 등 에러 코드
-    private String message;  // "잘못된 입력입니다" 등 메시지
+import java.time.LocalDateTime;
 
-    public static ErrorResponse of(String code, String message) {
-        return new ErrorResponse("error", code, message);
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String status;   // "error" (고정값 유지)
+    private final String code;     // "C001"
+    private final String message;  // "잘못된 입력입니다."
+    private final LocalDateTime timestamp; // 에러 발생 시간 추가 추천
+
+    // ErrorCode 인터페이스를 받아서 변환하는 메서드
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status("error")
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/main/java/kr/gilmok/common/exception/CustomException.java
+++ b/src/main/java/kr/gilmok/common/exception/CustomException.java
@@ -4,16 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class CustomException extends RuntimeException {
-    // ErrorCode Enum은 나중에 팀원들이 채우더라도, 필드 타입은 String이나 Enum으로 열어두면 됨
-    // 지금은 단순하게 String code, message로 해두거나, ErrorCode Enum을 빈 껍데기로 만들어도 됨
-
-    private final String code;
-    private final String message;
-
-    public CustomException(String code, String message) {
-        super(message);
-        this.code = code;
-        this.message = message;
-    }
+    private final ErrorCode errorCode; // 핵심: 인터페이스 타입으로 받음
 }

--- a/src/main/java/kr/gilmok/common/exception/ErrorCode.java
+++ b/src/main/java/kr/gilmok/common/exception/ErrorCode.java
@@ -1,16 +1,9 @@
 package kr.gilmok.common.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
-    // 예시
-    INVALID_INPUT(400, "C001", "잘못된 입력입니다."),
-    UNAUTHORIZED(401, "C002", "인증이 필요합니다.");
-
-    private final int status;
-    private final String code;
-    private final String message;
+public interface ErrorCode {
+    HttpStatus getHttpStatus(); // e.g., HttpStatus.BAD_REQUEST
+    String getCode();           // e.g., "C001"
+    String getMessage();        // e.g., "잘못된 입력입니다."
 }

--- a/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
+++ b/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
@@ -1,0 +1,18 @@
+package kr.gilmok.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    // 기존에 있던 예시들 이동
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C002", "인증이 필요합니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C000", "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/gilmok/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/gilmok/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package kr.gilmok.common.exception;
+
+import kr.gilmok.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("CustomException: {} - {}", errorCode.getCode(), errorCode.getMessage());
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+}


### PR DESCRIPTION
## 🔍 What
- `ErrorCode`를 Interface로 변경하여 확장에 열려 있는 구조로 변경
- 각 마이크로서비스에서 독자적인 Enum을 정의하여 사용할 수 있도록 개선
- `GlobalExceptionHandler`를 통해 일관된 에러 응답 포맷(JSON) 유지


## 🔗 Issue
- Closes: #5

---
### ✅ 체크리스트
- [ ] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹 프레임워크 지원 추가
  * 글로벌 예외 처리 기능 구현

* **개선사항**
  * 오류 응답에 타임스탬프 정보 추가
  * 예외 처리 아키텍처 개선으로 더욱 견고한 오류 처리 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->