### PR TITLE
[feat] JWT 토큰 검증 성공/실패 횟수 측정을 위한 커스텀 메트릭 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     // 3. Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // 테스트
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/src/main/java/kr/gilmok/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/gilmok/common/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package kr.gilmok.common.filter;
 
 import io.jsonwebtoken.Claims;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +29,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Value("${app.jwt.secret}")
     private String secretKey;
 
+    private final MeterRegistry meterRegistry; // ⭐️ 추가: 메트릭 수집기 주입
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -43,6 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 4. SecurityContext에 인증 정보 저장
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Security Context에 '{}' 인증 정보를 저장했습니다.", authentication.getName());
+
+                // ✅ [추가] 토큰 검증 성공 메트릭 1 증가
+                // 프로메테우스에는 token_validation_total{result="success"} 로 저장됩니다.
+                meterRegistry.counter("token.validation", "result", "success").increment();
             }
         } catch (Exception e) {
             log.error("JWT 인증 에러: {}", e.getMessage());

--- a/src/main/java/kr/gilmok/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/kr/gilmok/common/security/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package kr.gilmok.common.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.gilmok.common.dto.ErrorResponse;
@@ -21,11 +22,16 @@ import java.io.IOException;
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry; // ⭐️ 추가: 메트릭 수집기 주입
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
 
         log.warn("Unauthorized Access Attempt - URI: [{}], Message: [{}]", request.getRequestURI(), authException.getMessage());
+
+        // ✅ [추가] 토큰 검증 실패 (또는 인증 없는 접근) 메트릭 1 증가
+        // 프로메테우스에는 token_validation_total{result="failure"} 로 저장됩니다.
+        meterRegistry.counter("token.validation", "result", "failure").increment();
 
         // 401 Unauthorized 응답 설정
         response.setContentType("application/json;charset=UTF-8");


### PR DESCRIPTION
## 🔍 What
- Common 모듈의 JWT 검증 흐름에서 토큰 검증 성공/실패 횟수를 집계하는 커스텀 메트릭 token_validation_total을 추가했습니다.
- JwtAuthenticationFilter에서 토큰 검증이 정상 통과하는 경우 result="success" 카운트를 증가시킵니다.
- CustomAuthenticationEntryPoint에서 인증 실패(401) 응답 직전에 result="failure" 카운트를 증가시킵니다.
​
## 🧪 How to test
- (전제) Common 서브모듈이 반영된 API 애플리케이션을 실행합니다.
- ​정상 토큰 케이스: Postman에서 API의 인증이 필요한 엔드포인트를 호출하면서 Authorization: Bearer <accessToken> 헤더로 정상 accessToken을 넣고 요청합니다.
- 비정상 토큰 케이스: 같은 요청에서 토큰을 일부 변경(마지막 문자 삭제/추가 등)하거나 토큰 없이 요청해서 401이 떨어지게 합니다.
메트릭 확인: API 서버의 /actuator/prometheus에서 아래 값이 각각 1 이상 증가하는지 확인합니다.
   - ​token_validation_total{result="success"}
   - token_validation_total{result="failure"}

## 🔗 Issue
- Closes: #17

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?