### PR TITLE
[feat] CommonSecurityConfig에 필터 확장 훅 추가

### DIFF
--- a/src/main/java/kr/gilmok/common/security/CommonSecurityConfig.java
+++ b/src/main/java/kr/gilmok/common/security/CommonSecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.gilmok.common.security;
 
+import jakarta.servlet.Filter;
 import kr.gilmok.common.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
+import java.util.Collections;
+import java.util.List;
+
 @RequiredArgsConstructor
 public abstract class CommonSecurityConfig {
 
@@ -20,6 +24,11 @@ public abstract class CommonSecurityConfig {
 
     protected abstract void configureRequestMatchers(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth);
+
+
+    protected List<Filter> getFiltersAfterJwtAuthentication() {
+        return Collections.emptyList();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -39,6 +48,10 @@ public abstract class CommonSecurityConfig {
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        for (Filter filter : getFiltersAfterJwtAuthentication()) {
+            http.addFilterAfter(filter, JwtAuthenticationFilter.class);
+        }
 
         return http.build();
     }


### PR DESCRIPTION
## 🔍 What
- JWT 인증 필터 이후 추가 필터를 등록할 수 있는 훅 메서드 추가.
- 기본 구현은 빈 리스트 반환으로 기존 모듈 영향 없음.

## 🧪 How to test
- api-repo에서 훅을 오버라이드한 뒤 해당 필터가 정상 동작하는지 확인.

## 🔗 Issue
- Closes: #25 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 보안 필터 체인 구성에 확장 가능성을 추가했습니다. JWT 인증 이후에 추가 필터를 주입할 수 있도록 보안 구조를 개선하여, 상속 클래스에서 커스텀 보안 필터를 더 유연하게 적용할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->