### PR TITLE
[feat] 토큰 보안 공통 모듈 구축 및 Redis 지원 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // 3. Spring Security
+    // 3. Spring Security & Redis
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    api 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // 테스트

--- a/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
+++ b/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
@@ -13,7 +13,10 @@ public enum GlobalErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C000", "서버 내부 오류입니다."),
     NOT_ENOUGH_KEY_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "JWT 시크릿은 최소 256비트(32바이트)여야 합니다."),
     INVALID_USER(HttpStatus.UNAUTHORIZED, "U001", "유효하지 않은 회원 정보입니다."),
-    INACTIVATED_USER(HttpStatus.FORBIDDEN, "U002", "비활성화된 회원 입니다.")
+    INACTIVATED_USER(HttpStatus.FORBIDDEN, "U002", "비활성화된 회원 입니다."),
+    
+    // 토큰 관련 공통 에러
+    ACCESS_TOKEN_BLOCKED(HttpStatus.UNAUTHORIZED, "AT004", "로그아웃된 토큰입니다. 다시 로그인해주세요.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
+++ b/src/main/java/kr/gilmok/common/exception/GlobalErrorCode.java
@@ -16,7 +16,8 @@ public enum GlobalErrorCode implements ErrorCode {
     INACTIVATED_USER(HttpStatus.FORBIDDEN, "U002", "비활성화된 회원 입니다."),
     
     // 토큰 관련 공통 에러
-    ACCESS_TOKEN_BLOCKED(HttpStatus.UNAUTHORIZED, "AT004", "로그아웃된 토큰입니다. 다시 로그인해주세요.")
+    ACCESS_TOKEN_BLOCKED(HttpStatus.UNAUTHORIZED, "AT004", "로그아웃된 토큰입니다. 다시 로그인해주세요."),
+    SECURITY_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "보안 시스템 장애로 인해 인증을 처리할 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
@@ -57,12 +57,6 @@ public class AccessTokenBlocklistFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 이미 인증 컨텍스트가 없으면 통과 (JwtAuthenticationFilter에서 처리됨)
-        if (SecurityContextHolder.getContext().getAuthentication() == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         String accessToken = resolveAccessTokenFromCookie(request);
         if (accessToken == null) {
             filterChain.doFilter(request, response);

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
@@ -12,7 +12,7 @@ import kr.gilmok.common.utils.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -74,14 +74,18 @@ public class AccessTokenBlocklistFilter extends OncePerRequestFilter {
             if (jti != null && accessTokenBlocklistRepository.isBlocked(jti)) {
                 log.warn("[Blocklist] 로그아웃된 토큰 접근 차단 - jti: {}", jti);
                 SecurityContextHolder.clearContext();
-
-                sendErrorResponse(response);
+                sendErrorResponse(response, GlobalErrorCode.ACCESS_TOKEN_BLOCKED);
                 return;
             }
         } catch (io.jsonwebtoken.JwtException e) {
             log.debug("[Blocklist] JWT 파싱 실패 (만료/잘못된 토큰): {}", e.getMessage());
         } catch (Exception e) {
-            log.warn("[Blocklist] 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            // [정책 결정] Fail-Closed: Redis 장애 등으로 블랙리스트 조회가 실패할 경우, 
+            // 보안을 위해 요청을 거부함.
+            log.error("[Blocklist] 보안 시스템 장애 - 요청을 거부합니다. Error: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+            sendErrorResponse(response, GlobalErrorCode.SECURITY_SYSTEM_ERROR);
+            return;
         }
 
         filterChain.doFilter(request, response);
@@ -97,11 +101,11 @@ public class AccessTokenBlocklistFilter extends OncePerRequestFilter {
                 .orElse(null);
     }
 
-    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+    private void sendErrorResponse(HttpServletResponse response, GlobalErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(errorCode.getHttpStatus().value());
 
-        ErrorResponse errorResponse = ErrorResponse.of(GlobalErrorCode.ACCESS_TOKEN_BLOCKED);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
         String json = objectMapper.writeValueAsString(errorResponse);
         response.getWriter().write(json);
     }

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
@@ -1,0 +1,106 @@
+package kr.gilmok.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.gilmok.common.dto.ErrorResponse;
+import kr.gilmok.common.exception.GlobalErrorCode;
+import kr.gilmok.common.utils.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * 공통 Access Token 블랙리스트 체크 필터.
+ * 로그아웃된 토큰(jti가 Redis 블랙리스트에 있는 경우)을 차단한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessTokenBlocklistFilter extends OncePerRequestFilter {
+
+    private static final Set<String> SKIP_PATHS = Set.of(
+            "/error", "/actuator/health", "/actuator/prometheus",
+            "/swagger-ui/**", "/v3/api-docs/**",
+            "/auth/login", "/auth/signup", "/auth/reissue", "/auth/logout"
+    );
+
+    private final AccessTokenBlocklistRepository accessTokenBlocklistRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.jwt.secret}")
+    private String secretKey;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return SKIP_PATHS.stream().anyMatch(skip -> {
+            if (skip.endsWith("/**")) {
+                return path.startsWith(skip.substring(0, skip.length() - 3));
+            }
+            return path.equals(skip);
+        });
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 이미 인증 컨텍스트가 없으면 통과 (JwtAuthenticationFilter에서 처리됨)
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = resolveAccessTokenFromCookie(request);
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String jti = JwtUtils.extractJti(accessToken, secretKey);
+            if (jti != null && accessTokenBlocklistRepository.isBlocked(jti)) {
+                log.warn("[Blocklist] 로그아웃된 토큰 접근 차단 - jti: {}", jti);
+                SecurityContextHolder.clearContext();
+
+                sendErrorResponse(response);
+                return;
+            }
+        } catch (Exception e) {
+            log.debug("[Blocklist] jti 추출 실패: {}", e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveAccessTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> "accessToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        ErrorResponse errorResponse = ErrorResponse.of(GlobalErrorCode.ACCESS_TOKEN_BLOCKED);
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistFilter.java
@@ -78,8 +78,10 @@ public class AccessTokenBlocklistFilter extends OncePerRequestFilter {
                 sendErrorResponse(response);
                 return;
             }
+        } catch (io.jsonwebtoken.JwtException e) {
+            log.debug("[Blocklist] JWT 파싱 실패 (만료/잘못된 토큰): {}", e.getMessage());
         } catch (Exception e) {
-            log.debug("[Blocklist] jti 추출 실패: {}", e.getMessage());
+            log.warn("[Blocklist] 예상치 못한 오류 발생: {}", e.getMessage(), e);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepository.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepository.java
@@ -1,0 +1,19 @@
+package kr.gilmok.common.security;
+
+public interface AccessTokenBlocklistRepository {
+
+    /**
+     * access token의 jti를 블랙리스트에 등록한다 (auth-repo 전용).
+     * @param jti 토큰의 JWT ID
+     * @param ttlMs 블랙리스트 보존 기간 (토큰 남은 유효시간, 밀리초)
+     */
+    default void block(String jti, long ttlMs) {
+        throw new UnsupportedOperationException("이 모듈에서는 블랙리스트 등록 기능이 지원되지 않습니다.");
+    }
+
+    /**
+     * jti가 블랙리스트에 존재하는지 확인한다.
+     * @return 블랙리스트에 있으면 true (= 로그아웃된 토큰)
+     */
+    boolean isBlocked(String jti);
+}

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
@@ -26,15 +26,23 @@ public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistR
         }
 
         redisTemplate.opsForValue().set(
-                KEY_PREFIX + jti,
+                buildKey(jti),
                 "1",
                 ttlMs,
                 TimeUnit.MILLISECONDS
         );
     }
 
+    private String buildKey(String jti) {
+        if (jti == null || jti.isBlank()) {
+            throw new IllegalArgumentException("jti must not be null or blank");
+        }
+        return KEY_PREFIX + jti;
+    }
+
     @Override
     public boolean isBlocked(String jti) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + jti));
+        if (jti == null || jti.isBlank()) return false;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(buildKey(jti)));
     }
 }

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
@@ -1,0 +1,35 @@
+package kr.gilmok.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redis 기반 Access Token 블랙리스트 구현체 (공통).
+ */
+@Repository
+@RequiredArgsConstructor
+public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistRepository {
+
+    private static final String KEY_PREFIX = "blocklist:jti:";
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void block(String jti, long ttlMs) {
+        if (ttlMs <= 0) return;
+        
+        redisTemplate.opsForValue().set(
+                KEY_PREFIX + jti,
+                "1",
+                ttlMs,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    @Override
+    public boolean isBlocked(String jti) {
+        return redisTemplate.hasKey(KEY_PREFIX + jti);
+    }
+}

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.gilmok.common.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +12,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistRepository {
 
     private static final String KEY_PREFIX = "blocklist:jti:";
@@ -18,7 +20,10 @@ public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistR
 
     @Override
     public void block(String jti, long ttlMs) {
-        if (ttlMs <= 0) return;
+        if (ttlMs <= 0) {
+            log.warn("[Blocklist] skip block registration: invalid ttlMs={}, jti={}", ttlMs, jti);
+            return;
+        }
 
         redisTemplate.opsForValue().set(
                 KEY_PREFIX + jti,

--- a/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
+++ b/src/main/java/kr/gilmok/common/security/AccessTokenBlocklistRepositoryImpl.java
@@ -19,7 +19,7 @@ public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistR
     @Override
     public void block(String jti, long ttlMs) {
         if (ttlMs <= 0) return;
-        
+
         redisTemplate.opsForValue().set(
                 KEY_PREFIX + jti,
                 "1",
@@ -30,6 +30,6 @@ public class AccessTokenBlocklistRepositoryImpl implements AccessTokenBlocklistR
 
     @Override
     public boolean isBlocked(String jti) {
-        return redisTemplate.hasKey(KEY_PREFIX + jti);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + jti));
     }
 }

--- a/src/main/java/kr/gilmok/common/utils/JwtUtils.java
+++ b/src/main/java/kr/gilmok/common/utils/JwtUtils.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Date;
 
 @Slf4j
 public class JwtUtils {
@@ -37,6 +38,16 @@ public class JwtUtils {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public static String extractJti(String token, String secretKey) {
+        return extractClaims(token, secretKey).getId();
+    }
+
+    public static long getRemainingTtlMs(String token, String secretKey) {
+        Date expiration = extractClaims(token, secretKey).getExpiration();
+        long remaining = expiration.getTime() - System.currentTimeMillis();
+        return Math.max(0, remaining);
     }
 
     private static Key getSigningKey(String secretKey) {


### PR DESCRIPTION
## 🔍 What
- 서비스 전반에서 사용할 Access Token 블랙리스트 검증 로직 공통화

## 🔗 Issue
- Closes: #27 
- Refs: #27 

---
### ✅ 체크리스트
- [x] base가 **main**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃된 토큰 접근을 차단해 차단된 토큰으로의 요청은 401 응답과 명확한 오류 메시지로 거부됩니다.
  * 중앙 Redis 기반 토큰 차단 목록 지원이 추가되어 토큰 차단/조회가 가능해졌습니다.
  * 토큰의 식별자(JTI) 추출 및 잔여 TTL 확인 유틸리티가 추가되어 인증 흐름이 강화됩니다.

* **오류 처리**
  * 차단 검사 중 시스템 오류 발생 시 500 상태와 적절한 오류 응답을 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->